### PR TITLE
ci(release): grant token contents:write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Add permissions: contents: write to .github/workflows/release.yml so softprops/action-gh-release can create releases. After merging, re-run the failed v0.1.0 release workflow (or re-push the tag).